### PR TITLE
Make Room.paths a single object, keyed by directions (e.g. N or North)

### DIFF
--- a/app/player/room.coffee
+++ b/app/player/room.coffee
@@ -16,28 +16,24 @@ define [ "jquery", "item", "inventory", "vendor/underscore" ], ($, Item, Invento
     get: (room, roomItems) ->
       $("#move a").attr "href", "#"
       $("#move li").addClass "disabled"
-      for i of room.paths
-        direction = room.paths[i].direction
-        if direction is "North"
-          $("#move-compass-north a").attr "href", room.paths[i].name
-          $("#move-compass-north, #move-compass-north a").removeClass "disabled"
-        else if direction is "South"
-          $("#move-compass-south a").attr "href", room.paths[i].name
-          $("#move-compass-south, #move-compass-south a").removeClass "disabled"
-        else if direction is "East"
-          $("#move-compass-east a").attr "href", room.paths[i].name
-          $("#move-compass-east, #move-compass-east a").removeClass "disabled"
-        else if direction is "West"
-          $("#move-compass-west a").attr "href", room.paths[i].name
-          $("#move-compass-west, #move-compass-west a").removeClass "disabled"
-
-  $(document).bind "roomChanged", (e, room) ->
-    console.log "yes i know i changed", arguments
+      for direction, name of room.paths
+        switch direction
+          when "North", "N"
+            $("#move-compass-north a").attr "href", name
+            $("#move-compass-north, #move-compass-north a").removeClass "disabled"
+          when "South", "S"
+            $("#move-compass-south a").attr "href", name
+            $("#move-compass-south, #move-compass-south a").removeClass "disabled"
+          when "East", "E"
+            $("#move-compass-east a").attr "href", name
+            $("#move-compass-east, #move-compass-east a").removeClass "disabled"
+          when "West", "W"
+            $("#move-compass-west a").attr "href", name
+            $("#move-compass-west, #move-compass-west a").removeClass "disabled"
 
   $(document).bind "roomReady", (e, room) ->
-    roomItems = _(Item.allById).filter((item, id) ->
+    roomItems = _(Item.allById).filter (item, id) ->
       item.location is room.name
-    )
     Room.get room, roomItems
 
   Room

--- a/public/game_data/hmm.yaml
+++ b/public/game_data/hmm.yaml
@@ -31,12 +31,9 @@ rooms:
   name: Living Room
   description: You are in the living room. There is a jackalope head mounted on the wall, an old coffee table that Joe's parents gave him on the floor, and you're sitting on a couch.
   paths: 
-  - name: Joe's Room
-    direction: South
-  - name: Kitchen
-    direction: North
-  - name: Bathroom
-    direction: East
+    South: Joe's Room
+    North: Kitchen
+    East: Bathroom
   items: 
   - name: Coffee Table
     look: 
@@ -74,24 +71,21 @@ rooms:
 - name: Joe's Room
   description: You are in Joe's room. There is a thirty square-foot black light poster of Jimi Hendrix on the wall. There is nothing else in the room.
   paths: 
-  - name: Living Room
-    direction: North
+    North: Living Room
   items: 
   - name: Hendrix Poster
     take: true
 - name: Bathroom
   description: You are in Joe's bathroom. There is a plentiful supply of floss.
   paths: 
-  - name: Living Room
-    direction: West
+    West: Living Room
   items: 
   - name: Toilet
     take: true
 - name: Kitchen
   description: You are in the kitchen. I GOT YA ALL IN CHEQUE
   paths: 
-  - name: Living Room
-    direction: South
+    South: Living Room
   items: 
   - name: Stove
     take: true

--- a/public/game_data/stonehenge.json
+++ b/public/game_data/stonehenge.json
@@ -38,9 +38,7 @@
   "rooms" : [
     { "starter" : true,
       "name": "The Tree",
-  	  "paths": [
-  		  {"name": "Stonehenge", "direction": "North"}
-  	  ],
+  	  "paths": {"North": "Stonehenge"},
       "description": "You stand at the base of a tree. Its leaves are prized for their medicinal qualities.",
       "items": [
         { "name": "Rake", "id": "rake", "look": ["The rake is a bit rusty."], "take": true},
@@ -71,7 +69,7 @@
 
   	{
   	  "name" : "Stonehenge",
-  	  "paths": [ {"name": "The Tree", "direction": "South"} ],
+  	  "paths": {"South": "The Tree"},
   	  "description" : "Ancient power fills the air. The stone formation encircles a bubbling cauldron.",
   	  "items" : [
     		{ "name" : "Cauldron",

--- a/public/game_data/stonehenge.yaml
+++ b/public/game_data/stonehenge.yaml
@@ -32,8 +32,7 @@ rooms:
 - starter: true
   name: The Tree
   paths: 
-  - name: Stonehenge
-    direction: North
+    North: Stonehenge
   description: You stand at the base of a tree. Its leaves are prized for their medicinal qualities.
   items: 
   - name: Rake
@@ -59,8 +58,7 @@ rooms:
         after: dropRakeOnTree
 - name: Stonehenge
   paths: 
-  - name: The Tree
-    direction: South
+    South: The Tree
   description: Ancient power fills the air. The stone formation encircles a bubbling cauldron.
   items: 
   - name: Cauldron

--- a/public/js/room.js
+++ b/public/js/room.js
@@ -18,34 +18,41 @@ define(["jquery", "item", "inventory", "vendor/underscore"], function($, Item, I
       });
     },
     get: function(room, roomItems) {
-      var direction, i, _results;
+      var direction, name, _ref, _results;
       $("#move a").attr("href", "#");
       $("#move li").addClass("disabled");
+      _ref = room.paths;
       _results = [];
-      for (i in room.paths) {
-        direction = room.paths[i].direction;
-        if (direction === "North") {
-          $("#move-compass-north a").attr("href", room.paths[i].name);
-          _results.push($("#move-compass-north, #move-compass-north a").removeClass("disabled"));
-        } else if (direction === "South") {
-          $("#move-compass-south a").attr("href", room.paths[i].name);
-          _results.push($("#move-compass-south, #move-compass-south a").removeClass("disabled"));
-        } else if (direction === "East") {
-          $("#move-compass-east a").attr("href", room.paths[i].name);
-          _results.push($("#move-compass-east, #move-compass-east a").removeClass("disabled"));
-        } else if (direction === "West") {
-          $("#move-compass-west a").attr("href", room.paths[i].name);
-          _results.push($("#move-compass-west, #move-compass-west a").removeClass("disabled"));
-        } else {
-          _results.push(void 0);
+      for (direction in _ref) {
+        name = _ref[direction];
+        switch (direction) {
+          case "North":
+          case "N":
+            $("#move-compass-north a").attr("href", name);
+            _results.push($("#move-compass-north, #move-compass-north a").removeClass("disabled"));
+            break;
+          case "South":
+          case "S":
+            $("#move-compass-south a").attr("href", name);
+            _results.push($("#move-compass-south, #move-compass-south a").removeClass("disabled"));
+            break;
+          case "East":
+          case "E":
+            $("#move-compass-east a").attr("href", name);
+            _results.push($("#move-compass-east, #move-compass-east a").removeClass("disabled"));
+            break;
+          case "West":
+          case "W":
+            $("#move-compass-west a").attr("href", name);
+            _results.push($("#move-compass-west, #move-compass-west a").removeClass("disabled"));
+            break;
+          default:
+            _results.push(void 0);
         }
       }
       return _results;
     }
   };
-  $(document).bind("roomChanged", function(e, room) {
-    return console.log("yes i know i changed", arguments);
-  });
   $(document).bind("roomReady", function(e, room) {
     var roomItems;
     roomItems = _(Item.allById).filter(function(item, id) {


### PR DESCRIPTION
Should be a little bit easier to write, especially in YAML.

```
paths: 
  - name: Joe's Room
    direction: South
  - name: Kitchen
    direction: North
  - name: Bathroom
    direction: East
```

becomes

```
paths: 
    South: Joe's Room
    North: Kitchen
    East: Bathroom
```

I think there are other places we can start really trying to tighten up the syntax, identify inconsistencies etc.  What are your pet peeves? Let's discuss on the issues page!
